### PR TITLE
DEVOPS 382: check if system is registered on JC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ before_install:
     # Ansible doesn't play well with virtualenv
   - deactivate
   - sudo apt-get update -qq
-  - sudo apt-get install -y -o Dpkg::Options::="--force-confnew" docker-ce
+  - sudo apt-get install -y --allow-unauthenticated -o Dpkg::Options::="--force-confnew" docker-ce
 
 install:
   - sudo pip install docker-py
     # software-properties-common for ubuntu 14.04
     # python-software-properties for ubuntu 12.04
-  - sudo apt-get install -y sshpass software-properties-common python-software-properties
+  - sudo apt-get install -y --allow-unauthenticated sshpass software-properties-common python-software-properties
   - sudo apt-add-repository -y ppa:ansible/ansible
   - sudo apt-get update -qq
-  - sudo apt-get install -y ansible
+  - sudo apt-get install -y --allow-unauthenticated ansible
   - sudo rm /usr/bin/python && sudo ln -s /usr/bin/python2.7 /usr/bin/python
   - ansible --version
   - ansible-galaxy install -v -f -r tests/requirements.yml

--- a/tasks/check_system_registration.yml
+++ b/tasks/check_system_registration.yml
@@ -1,9 +1,8 @@
 ---
-
-- name: Update System Information
+- name: retrive System attributes based on the System ID
   uri:
     url: "{{ jumpcloud_api_v1_url }}/systems/{{ jumpcloud_system_key }}"
-    method: PUT
+    method: GET
     headers:
       "Content-Type": "application/json"
       "Accept":       "application/json"
@@ -18,6 +17,17 @@
     return_content: yes
     status_code: 200
   delegate_to: localhost
-  register: http_outcome
+  register:  jc_system_attributes_json_response
+  ignore_errors: yes
   when: jumpcloud_system_key is defined
+
+- name: Define if System is registered in JumpCloud
+  set_fact:
+    jc_system_is_registered: "{{ not jc_system_attributes_json_response.failed }}"
+  when: jc_system_attributes_json_response is defined
+  delegate_to: localhost
+
+- debug:
+    msg: "Warning ==> the System is not registered in JumpCloud"
+  when: not jc_system_is_registered
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-- name:       check JumpCloud agent config
+- name:       find JumpCloud agent config to define if JumpCloud is installed
   stat:
     path:     "{{ jumpcloud_agent_config }}"
   register:   jumpcloud_agent_config_status
 
-- name:       check if JumpCloud is installed
-  set_fact:
+- set_fact:
     jumpcloud_is_installed: "{{ (jumpcloud_agent_config_status.stat.isreg is defined and jumpcloud_agent_config_status.stat.isreg) }}"
 
 - name:       Install JumpCloud dependencies if required
@@ -16,19 +15,27 @@
   import_tasks: install.yml
   when:       not jumpcloud_is_installed or jumpcloud_force_install
 
-- name:        Get JumpCloud SystemKey
-  command:     grep -o -P '(?<=systemKey\":\")[a-zA-Z0-9]*' {{ jumpcloud_agent_config }}
-  register:    jumpcloud_system_key
-  become:      "{{ jumpcloud_use_sudo }}"
-  when:        jumpcloud_is_installed
-  changed_when: "not jumpcloud_system_key.stdout"
+- name:       Get JumpCloud SystemKey
+  command:    grep -o -P '(?<=systemKey\":\")[a-zA-Z0-9]*' {{ jumpcloud_agent_config }}
+  register:   jumpcloud_system_key_result
+  become:     "{{ jumpcloud_use_sudo }}"
+  when:       jumpcloud_is_installed
+  changed_when: "not jumpcloud_system_key_result.stdout"
 
-- name:       Update System Attributes if JumpCloud is insalled
-  import_tasks:    update_system.yml
+- set_fact:
+    jumpcloud_system_key: "{{ jumpcloud_system_key_result.stdout }}"
   when:       jumpcloud_is_installed
 
-- name:       Add System to Groups if Groups are defined
+- name:       Check System Registration
+  import_tasks:    check_system_registration.yml
+  when:       jumpcloud_system_key is defined
+
+- name:       Update System Attributes if the System is registered in JumpCloud
+  import_tasks:    update_system.yml
+  when:       jc_system_is_registered
+
+- name:       Add System to Groups if Groups are defined and the System is registered in JumpCloud
   import_tasks:    update_groups.yml
-  when:       jumpcloud_is_installed and jumpcloud_system_groups is defined
+  when:       jc_system_is_registered and jumpcloud_system_groups is defined
 
 ...

--- a/tasks/update_groups.yml
+++ b/tasks/update_groups.yml
@@ -13,7 +13,7 @@
   delegate_to: localhost
   register:  jc_system_groups_json_response
   ignore_errors: yes
-  when: jumpcloud_system_key is defined and jumpcloud_system_groups is defined
+  when: jumpcloud_system_groups is defined
 
 - name: Create the list of System Groups attributes
   set_fact: jc_system_groups={{ jc_system_groups|default([]) | union(item.json) }}
@@ -30,7 +30,7 @@
       "Accept":       "application/json"
       "x-api-key":    "{{ jumpcloud_api_key }}"
     body_format:  json
-    body: '{ "op": "add","type": "system", "id": "{{ jumpcloud_system_key.stdout }}" }'
+    body: '{ "op": "add","type": "system", "id": "{{ jumpcloud_system_key }}" }'
     follow_redirects: all
     return_content: yes
     # 204 = Successfully added, 409 = Already member

--- a/tests/inventory
+++ b/tests/inventory
@@ -2,7 +2,7 @@
 ubuntu1804 image=ubuntu:18.04
 ubuntu1604 image=ubuntu:16.04
 ubuntu1404 image=ubuntu:14.04
-ubuntu1204 image=chrismeyers/ubuntu12.04
+#ubuntu1204 image=chrismeyers/ubuntu12.04
 
 
 [centos]

--- a/tests/inventory-ubuntu
+++ b/tests/inventory-ubuntu
@@ -2,7 +2,7 @@
 ubuntu1804 image=ubuntu:18.04
 ubuntu1604 image=ubuntu:16.04
 ubuntu1404 image=ubuntu:14.04
-ubuntu1204 image=chrismeyers/ubuntu12.04
+#ubuntu1204 image=chrismeyers/ubuntu12.04
 
 [docker_containers:children]
 ubuntu

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -39,7 +39,7 @@
 
   pre_tasks:
     - name: Update the hostname
-      raw: bash -c "(hostname | grep -x {{ inventory_hostname }}test-with-ansible) || hostname {{ inventory_hostname }}test-with-ansible"
+      raw: bash -c "(hostname | grep -x {{ inventory_hostname }}-test-with-ansible) || hostname {{ inventory_hostname }}-test-with-ansible"
       register: output
       changed_when: output.stdout == ""
 

--- a/tests/tasks/fix_apt_show_versions.yml
+++ b/tests/tasks/fix_apt_show_versions.yml
@@ -5,13 +5,14 @@
     changed_when: output.stdout != ""
     when:  '"debian" in inventory_hostname or "ubuntu" in inventory_hostname'
     become: "{{ jumpcloud_use_sudo }}"
+    ignore_errors: true
 
-  - name: Purge "apt-show-versions"
-    raw: bash -c "apt-get -y purge apt-show-versions"
-    register: output
-    changed_when: output.stdout != ""
-    when:  '"debian" in inventory_hostname or "ubuntu" in inventory_hostname'
-    become: "{{ jumpcloud_use_sudo }}"
+  # - name: Purge "apt-show-versions"
+  #   raw: bash -c "apt-get -y purge apt-show-versions"
+  #   register: output
+  #   changed_when: false
+  #   when:  '"debian" in inventory_hostname or "ubuntu" in inventory_hostname'
+  #   become: "{{ jumpcloud_use_sudo }}"
 
   - name: Remove "/var/lib/apt/lists/*lz4"
     raw: bash -c "rm /var/lib/apt/lists/*lz4"
@@ -24,7 +25,7 @@
   - name: Set "Acquire::GzipIndexes=false"
     raw: bash -c "apt-get -o Acquire::GzipIndexes=false update"
     register: output
-    changed_when: output.stdout != ""
+    changed_when: false
     when:  '"debian" in inventory_hostname or "ubuntu" in inventory_hostname'
     become: "{{ jumpcloud_use_sudo }}"
 

--- a/tests/tasks/test_tasks.yml
+++ b/tests/tasks/test_tasks.yml
@@ -1,4 +1,40 @@
 ---
+# - name: Retrive host information from JumpCloud
+#   uri:
+#     url: "{{ jumpcloud_api_v1_url }}/systems/{{ jumpcloud_system_key }}"
+#     method: GET
+#     headers:
+#       "Content-Type": "application/json"
+#       "Accept":       "application/json"
+#       "x-api-key":    "{{ jumpcloud_api_key }}"
+#     body_format:  json
+#     body: '{ "displayName" : "{{ jumpcloud_displayName }}",
+#     "allowPublicKeyAuthentication" : "{{ jumpcloud_allowPublicKeyAuthentication }}",
+#     "allowSshPasswordAuthentication" : "{{ jumpcloud_allowSshPasswordAuthentication }}",
+#     "allowSshRootLogin" : "{{ jumpcloud_allowSshRootLogin }}",
+#     "allowMultiFactorAuthentication" : "{{ jumpcloud_allowMultiFactorAuthentication }}" }'
+#     follow_redirects: all
+#     return_content: yes
+#     status_code: 200
+#   delegate_to: localhost
+#   register: jc_system_json_response
+#   when: jumpcloud_system_key is defined
+#   ignore_errors: yes
+#
+# - debug:
+#     var: jc_system_json_response
+#
+# - name: Check that the host has been added to JumpCloud
+#   assert:
+#     that:
+#       - "jumpcloud_displayName in jc_system_json_response.json.displayName"
+#     msg: "The host should be named {{jumpcloud_displayName}} but is present in JumpCloud as {{jc_system_json_response.json.displayName}}"
+#   delegate_to: localhost
+
+- include_role:
+    name: ansible-jumpcloud
+    tasks_from: check_system_registration
+
 - name: Check that the host has been added to JumpCloud
   assert:
     that:
@@ -40,7 +76,6 @@
   with_items: "{{ jc_system_memberof_json_response.json}}"
   delegate_to: localhost
   when: jumpcloud_system_groups is defined
-  no_log: True
 
 - name: Check that the host is member of the required groups
   assert:

--- a/tests/tasks/test_tasks.yml
+++ b/tests/tasks/test_tasks.yml
@@ -1,36 +1,22 @@
 ---
-- name: Retrive host information from JumpCloud
-  uri:
-    url: "{{ jumpcloud_api_v1_url }}/systems/{{ jumpcloud_system_key.stdout }}"
-    method: GET
-    headers:
-      "Content-Type": "application/json"
-      "Accept":       "application/json"
-      "x-api-key":    "{{ jumpcloud_api_key }}"
-    body_format:  json
-    body: '{ "displayName" : "{{ jumpcloud_displayName }}",
-    "allowPublicKeyAuthentication" : "{{ jumpcloud_allowPublicKeyAuthentication }}",
-    "allowSshPasswordAuthentication" : "{{ jumpcloud_allowSshPasswordAuthentication }}",
-    "allowSshRootLogin" : "{{ jumpcloud_allowSshRootLogin }}",
-    "allowMultiFactorAuthentication" : "{{ jumpcloud_allowMultiFactorAuthentication }}" }'
-    follow_redirects: all
-    return_content: yes
-    status_code: 200
-  delegate_to: localhost
-  register: jc_system_json_response
-  when: jumpcloud_system_key is defined
-  ignore_errors: yes
-
 - name: Check that the host has been added to JumpCloud
   assert:
     that:
-      - "jumpcloud_displayName in jc_system_json_response.json.displayName"
-    msg: "The host should be named {{jumpcloud_displayName}} but is present in JumpCloud as {{jc_system_json_response.json.displayName}}"
+      - "jc_system_is_registered"
+    msg: "The host {{jumpcloud_displayName}} has not been registered to Jumpcloud"
+  delegate_to: localhost
+
+- name: Check that the registered host name correspond to the System hostname
+  assert:
+    that:
+      - "jumpcloud_displayName in jc_system_attributes_json_response.json.displayName"
+    msg: "The host should be named {{jumpcloud_displayName}} but is present in JumpCloud as {{jc_system_attributes_json_response.json.displayName}}"
+  when: jc_system_is_registered
   delegate_to: localhost
 
 - name: Retrive the list of System Groups the host is member of
   uri:
-    url: "{{ jumpcloud_api_v2_url }}/systems/{{ jumpcloud_system_key.stdout }}/memberof"
+    url: "{{ jumpcloud_api_v2_url }}/systems/{{ jumpcloud_system_key }}/memberof"
     method: GET
     headers:
       "Content-Type": "application/json"
@@ -54,6 +40,7 @@
   with_items: "{{ jc_system_memberof_json_response.json}}"
   delegate_to: localhost
   when: jumpcloud_system_groups is defined
+  no_log: True
 
 - name: Check that the host is member of the required groups
   assert:

--- a/tests/tasks/test_tasks.yml
+++ b/tests/tasks/test_tasks.yml
@@ -76,6 +76,7 @@
   with_items: "{{ jc_system_memberof_json_response.json}}"
   delegate_to: localhost
   when: jumpcloud_system_groups is defined
+  no_log: true
 
 - name: Check that the host is member of the required groups
   assert:


### PR DESCRIPTION
- add a task to verify if the system is registered in JC
- use the result as a condition to update system and groups attributes on JC portal
- update idempotency test for Debian system
- remove Ubuntu 12.04 test support because old CURL version does not support TLSv12