### PR TITLE
Add missing become (sudo) task arguments

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,6 +34,7 @@
   stat:
     path:     "{{ jumpcloud_agent_config }}"
   register:   jumpcloud_agent_config_status
+  become:     "{{ jumpcloud_use_sudo }}"
 
 - name:       Check again if JumpCloud has been initialised
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   stat:
     path:     "{{ jumpcloud_agent_config }}"
   register:   jumpcloud_agent_config_status
+  become:     "{{ jumpcloud_use_sudo }}"
 
 - set_fact:
     jumpcloud_is_installed: "{{ (jumpcloud_agent_config_status.stat.isreg is defined and jumpcloud_agent_config_status.stat.isreg) }}"

--- a/tasks/reset_jumpcloud.yml
+++ b/tasks/reset_jumpcloud.yml
@@ -40,6 +40,7 @@
   stat:
     path:     "{{ jumpcloud_agent_config }}"
   register:   jumpcloud_agent_config_status
+  become:     "{{ jumpcloud_use_sudo }}"
 
 - name:       check again if JumpCloud is installed
   set_fact:


### PR DESCRIPTION
The JumpCloud agent config file is created using sudo (if requested by config), but subsequent `stat` calls on the file were not, meaning that they would fail.